### PR TITLE
Add teleport to the baseimage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+AWS_REGION ?= eu-west-1
+KUBERNETES_VERSION ?=
+
+DEBUG ?= false
+
+ifeq ($(DEBUG),true)
+  DEBUG_FLAG ?= -debug
+else
+  DEBUG_FLAG ?=
+endif
+
+build:
+	test -n "$(KUBERNETES_VERSION)"  # $$KUBERNETES_VERSION
+	
+	packer build $(DEBUG_FLAG) -var 'aws_region=$(AWS_REGION)' -var 'kubernetes_version=$(KUBERNETES_VERSION)' aws.json

--- a/aws.json
+++ b/aws.json
@@ -1,0 +1,59 @@
+{
+    "variables": {
+        "aws_region": "eu-west-1",
+        "aws_instance_type": "t2.medium",
+        "root_volume_size": "128",
+        "root_volume_type": "gp2",
+        "teleport_version": "2.3.5",
+        "kubernetes_version": ""
+    },
+    "builders": [{
+        "type": "amazon-ebs",
+        "region": "{{user `aws_region`}}",
+        "instance_type": "{{user `aws_instance_type`}}",
+        "ssh_username": "admin",
+        "ssh_pty": true,
+        "ami_name": "ebs-kubernetes-baseimage-{{isotime \"200601020304\"}}",
+        "ami_groups": "all",
+        "ami_block_device_mappings": [{
+            "device_name": "/dev/sda1",
+            "volume_size": "{{user `root_volume_size`}}",
+            "volume_type": "{{user `root_volume_type`}}",
+            "delete_on_termination": true
+        }],
+        "run_tags": {
+            "Project": "kubernetes-baseimage"
+        },
+        "tags": {
+            "Project": "kubernetes-baseimage"
+        },
+        "source_ami_filter": {
+            "filters": {
+                "virtualization-type": "hvm",
+                "name": "k8s-{{user `kubernetes_version`}}-debian-jessie-amd64-hvm-ebs.*"
+            },
+            "owners": ["383156758163"],
+            "most_recent": true
+        }
+    }],
+    "provisioners": [{
+        "type": "file",
+        "source": "files/teleport.yaml",
+        "destination": "/etc/teleport.yaml"
+    }, {
+        "type": "file",
+        "source": "files/teleport.service",
+        "destination": "/lib/systemd/system/teleport.service"
+    }, {
+        "type": "shell",
+        "script": "scripts/teleport.sh",
+        "environment_vars": [
+            "TELEPORT_VERSION={{user `teleport_version`}}"
+        ]
+    }],
+    "post-processors": [{
+        "type": "manifest",
+        "output": "packer_manifest.json",
+        "strip_path": true
+    }]
+}

--- a/aws.json
+++ b/aws.json
@@ -30,7 +30,7 @@
         "source_ami_filter": {
             "filters": {
                 "virtualization-type": "hvm",
-                "name": "k8s-{{user `kubernetes_version`}}-debian-jessie-amd64-hvm-ebs.*"
+                "name": "k8s-{{user `kubernetes_version`}}-debian-jessie-amd64-hvm-ebs-*"
             },
             "owners": ["383156758163"],
             "most_recent": true
@@ -39,11 +39,11 @@
     "provisioners": [{
         "type": "file",
         "source": "files/teleport.yaml",
-        "destination": "/etc/teleport.yaml"
+        "destination": "/tmp/teleport.yaml"
     }, {
         "type": "file",
         "source": "files/teleport.service",
-        "destination": "/lib/systemd/system/teleport.service"
+        "destination": "/tmp/teleport.service"
     }, {
         "type": "shell",
         "script": "scripts/teleport.sh",

--- a/ci/build-ami.yaml
+++ b/ci/build-ami.yaml
@@ -1,0 +1,26 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: "skyscrapers/packer"
+    tag: "1.0.4"
+
+params:
+  KUBERNETES_VERSION:
+
+inputs:
+  - name: packer
+
+outputs:
+  - name: outputs
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    cd packer
+
+    KUBERNETES_VERSION=$KUBERNETES_VERSION make build
+    cp packer_manifest.json ../outputs/

--- a/files/teleport.service
+++ b/files/teleport.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Teleport SSH Service
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/teleport
+Type=simple
+Restart=on-failure
+ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --nodename $NODENAME --advertise-ip $ADVERTISE_IP --auth-server $AUTH_SERVER --token $AUTH_TOKEN
+
+[Install]
+WantedBy=multi-user.target

--- a/files/teleport.yaml
+++ b/files/teleport.yaml
@@ -1,0 +1,13 @@
+ssh_service:
+    enabled: yes
+    listen_addr: 0.0.0.0:3022
+
+    commands:
+        - name: arch
+          command: [uname, -p]
+          period: 1h0m0s
+    permit_user_env: false
+auth_service:
+    enabled: no
+proxy_service:
+    enabled: no

--- a/scripts/teleport.sh
+++ b/scripts/teleport.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+curl -L "https://github.com/gravitational/teleport/releases/download/v$TELEPORT_VERSION/teleport-v$TELEPORT_VERSION-linux-amd64-bin.tar.gz" > /tmp/vault.zip
+
+cd /tmp
+sudo tar -xzf teleport.tar.gz
+
+sudo /tmp/teleport/install
+
+sudo systemctl daemon-reload

--- a/scripts/teleport.sh
+++ b/scripts/teleport.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -e
 
-curl -L "https://github.com/gravitational/teleport/releases/download/v$TELEPORT_VERSION/teleport-v$TELEPORT_VERSION-linux-amd64-bin.tar.gz" > /tmp/vault.zip
+# Copy from temp location to definitive location (Packer can only copy to locations where `admin` has access)
+sudo mv /tmp/teleport.yaml /etc/teleport.yaml
+sudo mv /tmp/teleport.service /lib/systemd/system/teleport.service
 
+# Download + install teleport
+curl -L "https://github.com/gravitational/teleport/releases/download/v$TELEPORT_VERSION/teleport-v$TELEPORT_VERSION-linux-amd64-bin.tar.gz" > /tmp/teleport.tar.gz
 cd /tmp
 sudo tar -xzf teleport.tar.gz
-
 sudo /tmp/teleport/install
 
+# Reload systemd to activate teleport service
 sudo systemctl daemon-reload


### PR DESCRIPTION
This is the first reason we need a custom baseimage for Kubernetes. This does the following:
- Choose AMI based on Kubernetes version
- Add teleport (install + systemd + main config)
- Add task for ConcourseCI