### PR TITLE
Gravitational has changed the way to download Teleport

### DIFF
--- a/k8s-baseimage/scripts/teleport.sh
+++ b/k8s-baseimage/scripts/teleport.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Download + install teleport
-curl -L "https://github.com/gravitational/teleport/releases/download/v$TELEPORT_VERSION/teleport-v$TELEPORT_VERSION-linux-amd64-bin.tar.gz" > /tmp/teleport.tar.gz
+curl -L "https://get.gravitational.com/teleport-v$TELEPORT_VERSION-linux-amd64-bin.tar.gz" > /tmp/teleport.tar.gz
 cd /tmp
 sudo tar -xzf teleport.tar.gz
 sudo /tmp/teleport/install

--- a/teleport/packer.json
+++ b/teleport/packer.json
@@ -4,7 +4,7 @@
     "aws_instance_type": "t2.micro",
     "source_ami": "",
     "teleport_version": "",
-    "teleport_download_url_format": "https://github.com/gravitational/teleport/releases/download/v%version%/teleport-v%version%-linux-amd64-bin.tar.gz"
+    "teleport_download_url_format": "https://get.gravitational.com/teleport-v%version%-linux-amd64-bin.tar.gz"
   },
   "builders": [
     {


### PR DESCRIPTION
Now we have to download the binaries from their site, instead of Github