### PR TITLE
Install AWS inspector on k8s images

### DIFF
--- a/k8s-baseimage/aws.json
+++ b/k8s-baseimage/aws.json
@@ -1,24 +1,24 @@
 {
     "variables": {
-        "aws_region": "eu-west-1",
-        "aws_instance_type": "t2.medium",
-        "root_volume_size": "8",
-        "root_volume_type": "gp2",
-        "teleport_version": "2.5.6",
+        "aws_region"        : "eu-west-1",
+        "aws_instance_type" : "t2.medium",
+        "root_volume_size"  : "8",
+        "root_volume_type"  : "gp2",
+        "teleport_version"  : "2.5.6",
         "kubernetes_version": ""
     },
     "builders": [{
-        "type": "amazon-ebs",
-        "region": "{{user `aws_region`}}",
-        "instance_type": "{{user `aws_instance_type`}}",
-        "ssh_username": "admin",
-        "ssh_pty": true,
-        "ami_name": "ebs-kubernetes-baseimage-{{user `kubernetes_version`}}-{{isotime \"200601020304\"}}",
-        "ami_groups": "all",
+        "type"                     : "amazon-ebs",
+        "region"                   : "{{user `aws_region`}}",
+        "instance_type"            : "{{user `aws_instance_type`}}",
+        "ssh_username"             : "admin",
+        "ssh_pty"                  : true,
+        "ami_name"                 : "ebs-kubernetes-baseimage-{{user `kubernetes_version`}}-{{isotime \"200601020304\"}}",
+        "ami_groups"               : "all",
         "ami_block_device_mappings": [{
-            "device_name": "/dev/xvda",
-            "volume_size": "{{user `root_volume_size`}}",
-            "volume_type": "{{user `root_volume_type`}}",
+            "device_name"          : "/dev/xvda",
+            "volume_size"          : "{{user `root_volume_size`}}",
+            "volume_type"          : "{{user `root_volume_type`}}",
             "delete_on_termination": true
         }],
         "run_tags": {
@@ -30,22 +30,28 @@
         "source_ami_filter": {
             "filters": {
                 "virtualization-type": "hvm",
-                "name": "k8s-{{user `kubernetes_version`}}-debian-jessie-amd64-hvm-ebs-*"
+                "name"               : "k8s-{{user `kubernetes_version`}}-debian-jessie-amd64-hvm-ebs-*"
             },
-            "owners": ["383156758163"],
+            "owners"     : ["383156758163"],
             "most_recent": true
         }
     }],
-    "provisioners": [{
-        "type": "shell",
-        "script": "scripts/teleport.sh",
-        "environment_vars": [
-            "TELEPORT_VERSION={{user `teleport_version`}}"
-        ]
-    }],
+    "provisioners": [
+        {
+            "type"            : "shell",
+            "script"          : "scripts/teleport.sh",
+            "environment_vars": [
+                "TELEPORT_VERSION={{user `teleport_version`}}"
+            ]
+        },
+        {
+            "type"  : "shell",
+            "script": "scripts/awsinspector.sh"
+        }
+    ],
     "post-processors": [{
-        "type": "manifest",
-        "output": "packer_manifest.json",
+        "type"      : "manifest",
+        "output"    : "packer_manifest.json",
         "strip_path": true
     }]
 }

--- a/k8s-baseimage/scripts/awsinspector.sh
+++ b/k8s-baseimage/scripts/awsinspector.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Download + install AWS Inspector
+curl -L https://inspector-agent.amazonaws.com/linux/latest/install -o /tmp/inspector_install
+cd /tmp
+sudo bash awsinspectorinstall

--- a/k8s-baseimage/scripts/awsinspector.sh
+++ b/k8s-baseimage/scripts/awsinspector.sh
@@ -4,4 +4,4 @@ set -e
 # Download + install AWS Inspector
 curl -L https://inspector-agent.amazonaws.com/linux/latest/install -o /tmp/inspector_install
 cd /tmp
-sudo bash awsinspectorinstall
+sudo bash inspector_install


### PR DESCRIPTION
Makes sure the AWS inspector is available on our images.

Related issue: https://github.com/skyscrapers/engineering/issues/43

Not tested