### PR TITLE
Fix certbot installation in teleport image

### DIFF
--- a/teleport/scripts/provision.sh
+++ b/teleport/scripts/provision.sh
@@ -15,8 +15,7 @@ sudo ./teleport/install
 # Install certbot
 sudo add-apt-repository -y ppa:certbot/certbot
 sudo apt-get update
-sudo apt-get install -y certbot python-pip
-sudo pip install certbot-dns-route53
+sudo apt-get install -y certbot python3-certbot-dns-route53
 
 # Download Cloudwatch logs agent and its dependencies. Setup is for the bootstrap phase
 sudo curl -o /root/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py


### PR DESCRIPTION
Apparently certbot uses python 3 when executed inside the cronjob, and we were previously installing the route53 plugin on python 2.7