### PR TITLE
Update teleport image and add cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ packer build -var 'source_ami=ami-0f9e9442edcd2faa2' -var 'kubernetes_version=1.
 AMI for Teleport servers. It basically contains the Teleport binaries and `certbot`. This image is built automatically in the [`server-images` pipeline on Concourse](https://ci.skyscrape.rs/teams/skyscrapers/pipelines/server-images), but if you need to build it manually, run `packer build` providing the correct variables, e.g.:
 
 ```bash
-packer build -var 'source_ami=ami-cc166eb5' -var 'teleport_version=2.4.2' packer.json
+packer build -var 'source_ami=ami-0ea3405d2d2522162' -var 'teleport_version=4.2.10' packer.json
 ```

--- a/common_scripts/al2_cleanup.sh
+++ b/common_scripts/al2_cleanup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Clean up yum caches to reduce the image size
+sudo yum clean all
+sudo rm -rf /var/cache/yum
+
+# Clean up files to reduce confusion during debug
+sudo rm -rf \
+    /etc/hostname \
+    /etc/machine-id \
+    /etc/resolv.conf \
+    /etc/ssh/ssh_host* \
+    /home/ec2-user/.ssh/authorized_keys \
+    /root/.ssh/authorized_keys \
+    /var/lib/cloud/data \
+    /var/lib/cloud/instance \
+    /var/lib/cloud/instances \
+    /var/lib/cloud/sem \
+    /var/lib/dhclient/* \
+    /var/lib/dhcp/dhclient.* \
+    /var/lib/yum/history \
+    /var/log/cloud-init-output.log \
+    /var/log/cloud-init.log \
+    /var/log/secure \
+    /var/log/wtmp \
+    /var/log/lastlog
+
+sudo touch /etc/machine-id
+sudo touch /var/log/lastlog

--- a/eks-baseimage/aws.json
+++ b/eks-baseimage/aws.json
@@ -63,6 +63,10 @@
         {
             "type": "shell",
             "script": "scripts/sysctl.sh"
+        },
+        {
+            "type": "shell",
+            "script": "../common_scripts/al2_cleanup.sh"
         }
     ],
     "post-processors": [

--- a/teleport/packer.json
+++ b/teleport/packer.json
@@ -4,7 +4,7 @@
     "aws_instance_type": "t2.micro",
     "source_ami": "",
     "teleport_version": "",
-    "teleport_download_url_format": "https://get.gravitational.com/teleport-v%version%-linux-amd64-bin.tar.gz"
+    "teleport_download_url_format": "https://get.gravitational.com/teleport-%version%-1.x86_64.rpm"
   },
   "builders": [
     {
@@ -12,7 +12,7 @@
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `source_ami`}}",
       "instance_type": "{{user `aws_instance_type`}}",
-      "ssh_username": "ubuntu",
+      "ssh_username": "ec2-user",
       "ssh_pty": true,
       "ami_name": "ebs-teleport-{{user `teleport_version`}}-{{isotime \"200601020304\"}}",
       "ami_groups": "all",
@@ -26,14 +26,20 @@
       }
     }
   ],
-  "provisioners": [{
-    "type": "shell",
-    "script": "scripts/provision.sh",
-    "environment_vars": [
-      "TELEPORT_DOWNLOAD_URL_FORMAT={{user `teleport_download_url_format`}}",
-      "TELEPORT_VERSION={{user `teleport_version`}}"
-    ]
-  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "scripts/provision.sh",
+      "environment_vars": [
+        "TELEPORT_DOWNLOAD_URL_FORMAT={{user `teleport_download_url_format`}}",
+        "TELEPORT_VERSION={{user `teleport_version`}}"
+      ]
+    },
+    {
+      "type": "shell",
+      "script": "../common_scripts/al2_cleanup.sh"
+    }
+  ],
   "post-processors": [
     {
       "type": "manifest",

--- a/teleport/scripts/provision.sh
+++ b/teleport/scripts/provision.sh
@@ -2,24 +2,20 @@
 
 set -e
 
-# Apt upgrade
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+cd /tmp
+
+sudo wget -r --no-parent -A 'epel-release-*.rpm' http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/
+sudo rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm
+sudo yum-config-manager --enable epel
+
+sudo yum update -y
 
 # Install teleport
-cd /tmp
-curl -sL `echo $TELEPORT_DOWNLOAD_URL_FORMAT | sed -e "s/%version%/$TELEPORT_VERSION/g"` > teleport.tar.gz
-sudo tar -xzf teleport.tar.gz
-sudo ./teleport/install
+sudo curl -sL `echo $TELEPORT_DOWNLOAD_URL_FORMAT | sed -e "s/%version%/$TELEPORT_VERSION/g"` > teleport.rpm
+sudo yum install -y teleport.rpm
 
 # Install certbot
-sudo add-apt-repository -y ppa:certbot/certbot
-sudo apt-get update
-sudo apt-get install -y certbot python3-certbot-dns-route53
+sudo yum install -y certbot python2-certbot-dns-route53
 
 # Download Cloudwatch logs agent and its dependencies. Setup is for the bootstrap phase
-sudo curl -o /root/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
-sudo curl -o /root/AgentDependencies.tar.gz https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/AgentDependencies.tar.gz
-
-# Cleanup
-sudo apt-get -y autoremove
+sudo yum install -y awslogs


### PR DESCRIPTION
- Switched teleport image from ubuntu to Amazon Linux 2
- Updated teleport to the latest version available (4.2.0)
- Add a common cleanup script