### PR TITLE
Don't run yum update for EKS AMI

### DIFF
--- a/eks-baseimage/aws.json
+++ b/eks-baseimage/aws.json
@@ -43,10 +43,6 @@
     "provisioners": [
         {
             "type": "shell",
-            "script": "scripts/update.sh"
-        },
-        {
-            "type": "shell",
             "script": "scripts/teleport.sh",
             "environment_vars": [
                 "TELEPORT_VERSION={{user `teleport_version`}}"

--- a/eks-baseimage/scripts/update.sh
+++ b/eks-baseimage/scripts/update.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-sudo yum -y update


### PR DESCRIPTION
While debugging https://github.com/skyscrapers/engineering/issues/403 and talking with @iuriaranda, we agreed that we better don't install updates on the EKS base AMI.

Reasoning is that these aren't officially tested and could break some unexpected things. The upstream images are updated regularly anyway. 