### PR TITLE
Allow to disable asw inspector

### DIFF
--- a/eks-baseimage/aws.json
+++ b/eks-baseimage/aws.json
@@ -2,6 +2,7 @@
     "variables": {
         "aws_region": "eu-west-1",
         "aws_instance_type": "t3.medium",
+        "aws_inspector_enabled": true,
         "root_volume_size": "8",
         "root_volume_type": "gp2",
         "teleport_version": "5.2.1",
@@ -50,7 +51,10 @@
         },
         {
             "type": "shell",
-            "script": "scripts/awsinspector.sh"
+            "script": "scripts/awsinspector.sh",
+            "environment_vars": [
+                "AWS_INSPECTOR_ENABLED={{user `aws_inspector_enabled`}}"
+            ]
         },
         {
             "type": "shell",

--- a/eks-baseimage/scripts/awsinspector.sh
+++ b/eks-baseimage/scripts/awsinspector.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-# Download + install AWS Inspector
-curl -L https://inspector-agent.amazonaws.com/linux/latest/install -o /tmp/inspector_install
-cd /tmp
-sudo bash inspector_install
+if $AWS_INSPECTOR_ENABLED; then
+  # Download + install AWS Inspector
+  curl -L https://inspector-agent.amazonaws.com/linux/latest/install -o /tmp/inspector_install
+  cd /tmp
+  sudo bash inspector_install
+fi


### PR DESCRIPTION
As it is not available in all regions:

```
    amazon-ebs: Aws Agent is only supported in us-east-1 us-west-1 us-west-2 ap-northeast-1 eu-west-1 eu-west-2 ap-northeast-2 ap-southeast-2 ap-south-1 eu-central-1 eu-north-1 us-east-2 us-gov-west-1 us-gov-east-1
    amazon-ebs: AWS Agent Inventory URL is not yet defined.
    amazon-ebs: Script exited with status code UNSUPPORTED_REGION ca-central-1
```